### PR TITLE
Enable submodules

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -63,7 +63,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ matrix.branch }}
-        submodules: `true`
+        submodules: 'true'
 
     - name: Cache page build
       id: cache-html

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        submodules: 'true'
 
     - id: set-branches
       name: Set branches

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -28,13 +28,10 @@ jobs:
     permissions:
       contents: read
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
 
     - id: set-branches
       name: Set branches

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -63,7 +63,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ matrix.branch }}
-        submodules: recursive
+        submodules: `true`
 
     - name: Cache page build
       id: cache-html

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: `recursive`
+        submodules: recursive
 
     - id: set-branches
       name: Set branches

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -31,7 +31,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: recursive
 
     - id: set-branches
       name: Set branches
@@ -64,6 +63,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ matrix.branch }}
+        submodules: recursive
 
     - name: Cache page build
       id: cache-html

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -28,10 +28,13 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
 
     - id: set-branches
       name: Set branches

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: 'true'
+        submodules: `recursive`
 
     - id: set-branches
       name: Set branches


### PR DESCRIPTION
Nested books rely on submodules, but these are not cloned automatically by the checkout action. Hence, pages from "sub-books" did not appear in book that used this feature (see https://github.com/TeachBooks/Nested-Books/issues/1).

This PR enables the option to also checkout submodules in the checkout stage of CI.

(cc @Tom-van-Woudenberg)