### PR TITLE
Read branches to preprocess from a variable

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -254,10 +254,12 @@ jobs:
         {
           echo "### Repository configuration variables"
           echo "Variables can be set at ${{ format('{0}/{1}/settings/variables/actions', github.server_url, github.repository) }}"
+          echo '```'
           echo "PRIMARY_BRANCH=$PRIMARY_BRANCH"
           echo "BRANCH_ALIASES=$BRANCH_ALIASES"
           echo "BRANCHES_TO_DEPLOY=$BRANCHES_TO_DEPLOY"
           echo "BRANCHES_TO_PREPROCESS=$BRANCHES_TO_PREPROCESS"
+          echo '```'
         } >> $GITHUB_STEP_SUMMARY
 
 

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -111,12 +111,16 @@ jobs:
         ref: ${{ matrix.branch }}
         submodules: 'true'
 
+    - name: Record if branch is preprocessed, for cache key
+      run: |
+        echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | { grep ${{ matrix.branch }} || true; } > VARS.txt
+
     - name: Cache page build
       id: cache-html
       uses: actions/cache@v4
       with:
         path: "book/_build/html"
-        key: html-build-${{ hashFiles('book/**', 'figures/**', 'requirements.txt') }}
+        key: html-build-${{ hashFiles('book/**', 'figures/**', 'requirements.txt', 'VARS.txt') }}
 
     - if: ${{ steps.cache-html.outputs.cache-hit != 'true' }}
       name: Set up Python 3.11

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -20,6 +20,10 @@ env:
   # Space-separated list of branch names, e.g. 'main second third'.
   # By default, deploy all branches. This is indicated by '*'.
   BRANCHES_TO_DEPLOY: ${{ vars.BRANCHES_TO_DEPLOY != '' && vars.BRANCHES_TO_DEPLOY || '*' }}
+  # Space-separated list of branch names, e.g. 'main second third'.
+  # By default, preprocess no branches ('').
+  # Preprocessing no branches can also be set by ' '.
+  BRANCHES_TO_PREPROCESS: ${{ vars.BRANCHES_TO_PREPROCESS }}
 
 jobs:
   get-branches:
@@ -129,8 +133,7 @@ jobs:
     - if: ${{ steps.cache-html.outputs.cache-hit != 'true' }}
       name: Preprocess & build the book from branch
       run: |
-        echo $PATH
-        if [ ${{matrix.branch}} == $PRIMARY_BRANCH ]; then
+        if [ "$BRANCHES_TO_PREPROCESS" == "*" ] || echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | grep "^${{matrix.branch}}$"; then
           option_publish='--publish'
         else
           option_publish=''

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -113,7 +113,10 @@ jobs:
 
     - name: Record if branch is preprocessed, for cache key
       run: |
-        echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | { grep ${{ matrix.branch }} || true; } > VARS.txt
+        echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | { grep "^${{ matrix.branch }}$" || true; } > VARS.txt
+        if [ "$BRANCHES_TO_PREPROCESS" == "*" ]; then
+          echo "${{ matrix.branch }}" > VARS.txt
+        fi
 
     - name: Cache page build
       id: cache-html

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -113,9 +113,10 @@ jobs:
 
     - name: Record if branch is preprocessed, for cache key
       run: |
-        echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | { grep "^${{ matrix.branch }}$" || true; } > VARS.txt
-        if [ "$BRANCHES_TO_PREPROCESS" == "*" ]; then
-          echo "${{ matrix.branch }}" > VARS.txt
+        if [ "$BRANCHES_TO_PREPROCESS" == "*" ] || echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | grep "^${{ matrix.branch }}$"; then
+          echo true > VARS.txt
+        else
+          echo false > VARS.txt
         fi
 
     - name: Cache page build
@@ -140,7 +141,7 @@ jobs:
     - if: ${{ steps.cache-html.outputs.cache-hit != 'true' }}
       name: Preprocess & build the book from branch
       run: |
-        if [ "$BRANCHES_TO_PREPROCESS" == "*" ] || echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | grep "^${{matrix.branch}}$"; then
+        if [ "$BRANCHES_TO_PREPROCESS" == "*" ] || echo "$BRANCHES_TO_PREPROCESS" | tr ' ' '\n' | grep "^${{ matrix.branch }}$"; then
           option_publish='--publish'
         else
           option_publish=''

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -242,8 +242,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
+
         echo "${{ needs.get-branches.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
         echo "${{ needs.deploy-books.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
+
+        # Display config var values
+        {
+          echo "### Repository configuration variables"
+          echo "Variables can be set at ${{ format('{0}/{1}/settings/variables/actions', github.server_url, github.repository) }}"
+          echo "PRIMARY_BRANCH=$PRIMARY_BRANCH"
+          echo "BRANCH_ALIASES=$BRANCH_ALIASES"
+          echo "BRANCHES_TO_DEPLOY=$BRANCHES_TO_DEPLOY"
+          echo "BRANCHES_TO_PREPROCESS=$BRANCHES_TO_PREPROCESS"
+        } >> $GITHUB_STEP_SUMMARY
+
+
 
 permissions:
   contents: read


### PR DESCRIPTION
Introduce a variable with same syntax as `BRANCHES_TO_DEPLOY`, for applying `--publish`. By default, preprocess none.

Tested manually for all combinations here https://github.com/TeachBooks/testable-template/actions/runs/8835925478

Resolves #3