### PR TITLE
Include repo name in venv cache key

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -141,7 +141,7 @@ jobs:
       name: Cache virtualenv
       uses: actions/cache@v4
       with:
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-week${{ env.WEEK }}
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-week${{ env.WEEK }}-${{ github.repository }}
         path: .venv
 
     - if: ${{ steps.cache-html.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
Should fix #30, as the cached venv would be invalidated (a new venv will be made)