### PR TITLE
Fix for user private repos

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -126,6 +126,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: read
     strategy:
       # If one branch fails, we may still want to deploy the other
       fail-fast: false

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -303,6 +303,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: read
     env:
       BRANCHES: ${{ needs.get-branches.outputs.branches }}
     steps:


### PR DESCRIPTION
Don't quite know why, additional permissions were needed: `contents: read`.
Example: https://severinbratus.github.io/testable-template-private/